### PR TITLE
[stable/jenkins] service account not used on RBAC

### DIFF
--- a/stable/jenkins/templates/jenkins-master-deployment.yaml
+++ b/stable/jenkins/templates/jenkins-master-deployment.yaml
@@ -51,6 +51,9 @@ spec:
               }
           ]'
     spec:
+      {{- if .Values.rbac.install }}
+      serviceAccountName: {{ template "fullname" . }}
+      {{- end }}
       {{- if .Values.Master.NodeSelector }}
       nodeSelector:
 {{ toYaml .Values.Master.NodeSelector | indent 8 }}


### PR DESCRIPTION
Master deployment should use service account if RBAC enabled.